### PR TITLE
Fix #12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ matrix:
   fast_finish: true
 script:
   - PYTHONPATH=".travis" coverage run .travis/cover.py -c 1 -n 100 .travis/$ENV.conf --btrees -r 2 --test-reps 1
-  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then PYTHONPATH=".travis" coverage run .travis/cover.py -c 2 -n 100 .travis/$ENV.conf --threads --gevent -r 2 --test-reps 2 --leaks; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then PYTHONPATH=".travis" coverage run .travis/cover.py -c 2 -n 100 .travis/$ENV.conf --threads -r 2 --test-reps 2; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then PYTHONPATH=".travis" coverage run .travis/cover.py -c 2 -n 100 .travis/$ENV.conf --threads --gevent -r 2 --test-reps 2 --leaks --dump-json; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then PYTHONPATH=".travis" coverage run .travis/cover.py -c 2 -n 100 .travis/$ENV.conf --threads -r 2 --test-reps 2 --dump-json; fi
 after_success:
   - coverage combine
   - coveralls

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,8 @@
 - Add ``--leaks`` to use `objgraph <http://mg.pov.lt/objgraph/>`_ to
   show any leaking objects at the end of each test repetition. Most
   useful to storage and ZODB developers.
+- Add ``--dump-json`` to write a JSON representation of more detailed
+  data than is present in the default CSV results.
 
 0.5 (2012-09-08)
 ================

--- a/doc/zodbshootout.rst
+++ b/doc/zodbshootout.rst
@@ -123,6 +123,15 @@ The ``zodbshootout`` script accepts the following options.
 
   .. versionadded:: 0.6
 
+* ``--dump-json`` writes a JSON structure containing the raw data
+  collected to the file given (or if no file is given, to stdout).
+  This can be useful for doing a more sophisticated analysis.
+
+  .. note:: The JSON structure is subject to change at any time.
+
+  .. versionadded:: 0.6
+
+
 You should write a configuration file that models your intended
 database and network configuration. Running ``zodbshootout`` may reveal
 configuration optimizations that would significantly increase your

--- a/src/zodbshootout/main.py
+++ b/src/zodbshootout/main.py
@@ -33,6 +33,7 @@ def main(argv=None):
     obj_group.add_argument(
         "-n", "--object-counts", dest="counts",
         type=int,
+        default=[],
         action="append",
         help="Object counts to use (default 1000). Use this option as many times as you want.",
         )
@@ -54,6 +55,7 @@ def main(argv=None):
     con_group.add_argument(
         "-c", "--concurrency", dest="concurrency",
         type=int,
+        default=[],
         action="append",
         help="Concurrency levels to use. Default is 2. Use this option as many times as you want."
         )

--- a/src/zodbshootout/speedtest.py
+++ b/src/zodbshootout/speedtest.py
@@ -277,12 +277,14 @@ class SpeedTest(object):
 
         # XXX: Several of these are already actually an average of several tests,
         # which we then average again here. Are we discarding information?
-        add_times = [t[0] for t in write_times]
-        update_times = [t[1] for t in write_times]
-        warm_times = [t[0] for t in read_times]
-        cold_times = [t[1] for t in read_times]
-        hot_times = [t[2] for t in read_times]
-        steamin_times = [t[3] for t in read_times]
+        add_times = [t.add_time for t in write_times]
+        update_times = [t.update_time for t in write_times]
+        warm_times = [t.warm_time for t in read_times]
+        cold_times = [t.cold_time for t in read_times]
+        hot_times = [t.hot_time for t in read_times]
+        steamin_times = [t.steamin_time for t in read_times]
 
-        return [statistics.mean(x)
-                for x in (add_times, update_times, warm_times, cold_times, hot_times, steamin_times)]
+        write_times = WriteTimes(*[statistics.mean(x) for x in (add_times, update_times)])
+        read_times = ReadTimes(*[statistics.mean(x) for x in (warm_times, cold_times, hot_times, steamin_times)])
+
+        return write_times, read_times

--- a/src/zodbshootout/speedtest.py
+++ b/src/zodbshootout/speedtest.py
@@ -80,7 +80,7 @@ class SpeedTest(object):
     MappingType = PersistentMapping
     debug = False
 
-    individual_test_reps = 20 # XXX configuration knob
+    individual_test_reps = 20
 
     def __init__(self, concurrency, objects_per_txn, object_size,
                  profile_dir=None,


### PR DESCRIPTION
Refactor the runner and speedtest to retain more information, and add an option to dump all that information for analysis.

This also fixes a bug where we were taking a mean of a median, which had to be losing information.
